### PR TITLE
Handle unsupported geolocation gracefully

### DIFF
--- a/docs/gdjs-evtsext__geolocation__compass.js
+++ b/docs/gdjs-evtsext__geolocation__compass.js
@@ -53,10 +53,14 @@ function updatePos(position) {
 }
 
 function failedUpdate(error) {
-    localMessage.setString("No GPS Signal");
+    localMessage.setString("Unable to retrieve GPS position");
 }
 
-navigator.geolocation.getCurrentPosition(updatePos, failedUpdate);
+if ('geolocation' in navigator) {
+    navigator.geolocation.getCurrentPosition(updatePos, failedUpdate);
+} else {
+    localMessage.setString("Geolocation is not supported");
+}
 };
 gdjs.evtsExt__GeoLocation__Compass.Compass.prototype.doStepPreEventsContext.eventsList0x70bf14 = function(runtimeScene, eventsFunctionContext) {
 


### PR DESCRIPTION
## Summary
- Check `navigator.geolocation` before usage in Compass extension
- Provide fallback GPS error message when geolocation is unsupported
- Improve failure handling message

## Testing
- `node --version`
- `node --check docs/gdjs-evtsext__geolocation__compass.js`


------
https://chatgpt.com/codex/tasks/task_e_689a07131764833092554a953161101f