### PR TITLE
Guard compass object lookup

### DIFF
--- a/docs/gdjs-evtsext__geolocation__compass.js
+++ b/docs/gdjs-evtsext__geolocation__compass.js
@@ -41,6 +41,9 @@ gdjs.evtsExt__GeoLocation__Compass.Compass.prototype.doStepPreEventsContext.user
 "use strict";
 
 const obj = eventsFunctionContext.getObjects('Object');
+if (!obj.length) {
+    return;
+}
 var localLat = obj[0].getVariables().get("Latitude");
 var localLong = obj[0].getVariables().get("Longitude");
 var localMessage = obj[0].getVariables().get("GPSMessage");
@@ -183,6 +186,9 @@ gdjs.evtsExt__GeoLocation__Compass.Compass.prototype.onCreatedContext.userFunc0x
 
 function handleOrientation(event) {
   const obj = eventsFunctionContext.getObjects('Object');
+  if (!obj.length) {
+    return;
+  }
   var localCompass = obj[0].getVariables().get("CompassHeading");
   var localNaked = obj[0].getVariables().get("NakedCompassHeading");
   
@@ -199,6 +205,9 @@ function handleOrientation(event) {
   
 if (window.DeviceOrientationEvent){
   const obj = eventsFunctionContext.getObjects('Object');
+  if (!obj.length) {
+    return;
+  }
   var localMessage = obj[0].getVariables().get("CompassMessage");
   if ('ondeviceorientationabsolute' in window) {
     localMessage.setString("Absolute");
@@ -210,8 +219,11 @@ if (window.DeviceOrientationEvent){
   }
 } else {
   const obj = eventsFunctionContext.getObjects('Object');
+  if (!obj.length) {
+    return;
+  }
   var localCompass = obj[0].getVariables().get("CompassHeading");
-  localCompass.setNumber(400); 
+  localCompass.setNumber(400);
 }
   
 };


### PR DESCRIPTION
## Summary
- avoid accessing `obj[0]` when the object list is empty in compass geolocation extension

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0715cc6083308b3d85064979b494