### PR TITLE
Check compass heading for undefined

### DIFF
--- a/docs/gdjs-evtsext__geolocation__compass.js
+++ b/docs/gdjs-evtsext__geolocation__compass.js
@@ -187,7 +187,7 @@ function handleOrientation(event) {
   var localNaked = obj[0].getVariables().get("NakedCompassHeading");
   
 
-  if(event.webkitCompassHeading) {
+  if (event.webkitCompassHeading !== undefined) {
     // Apple works only with this, alpha doesn't work
     localCompass.setNumber(event.webkitCompassHeading);
     localNaked.setNumber(event.webkitCompassHeading);     


### PR DESCRIPTION
## Summary
- ensure compass heading check tests for undefined before using `webkitCompassHeading`

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689a071442848330ad099caef693d772